### PR TITLE
多主题明暗色支持 ；按钮对齐方式修改

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "obsidian-to-mp",
+  "name": "mp-preview",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-to-mp",
+      "name": "mp-preview",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/src/view.ts
+++ b/src/view.ts
@@ -51,7 +51,7 @@ export class MPView extends ItemView {
         container.classList.remove('view-content');
         container.classList.add('mp-view-content');
         
-        const toolbar = container.createEl('div', { cls: 'mp-toolbar' });
+        const toolbar = container.createEl('div', { cls: 'mp-bottom-bar' });
         
         // 锁定按钮
         this.lockButton = toolbar.createEl('button', {
@@ -274,7 +274,10 @@ export class MPView extends ItemView {
         
         // 请作者喝咖啡按钮
         const likeButton = bottomControlsGroup.createEl('button', { 
-            cls: 'mp-like-button'
+            cls: ['mp-like-button', 'mod-cta'],
+            attr: {
+            style: 'background-color: var(--interactive-accent-hover); color: var(--text-on-accent);'
+            }
         });
         const heartSpan = likeButton.createEl('span', {
             text: '❤️',

--- a/src/view.ts
+++ b/src/view.ts
@@ -135,7 +135,7 @@ export class MPView extends ItemView {
             type: 'text',
             value: '16',
             attr: {
-                style: 'border: none; outline: none; background: transparent;'
+            style: 'border: none; outline: none; background: var(--background-primary);'
             }
         });
         const increaseButton = fontSizeGroup.createEl('button', { 

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,8 @@
     width: fit-content;
     min-width: fit-content;
     margin-left: 40px;
+    flex-wrap: wrap; /* Add flex-wrap to allow wrapping when space is tight */
+    padding: 5px 0; /* Add some padding to prevent items from touching when wrapped */
 }
 
 /* 锁定按钮 */
@@ -55,7 +57,9 @@
 /* 下拉选择器 */
 .custom-select-container {
     position: relative;
-    width: 120px;
+    width: fit-content;
+    /* min-width: 120px; */
+    margin-right: 8px;
 }
 
 .custom-select {
@@ -72,6 +76,8 @@
     transition: all 0.2s ease;
     color: var(--text-muted);
     box-shadow: 0 1px 3px var(--background-modifier-box-shadow);
+    width: fit-content;
+    min-width: min-content;
 }
 
 .custom-select:hover {
@@ -136,7 +142,7 @@
     align-items: center;
     justify-content: space-between;
     height: 32px;
-    background: white;
+    background: var(--background-primary);
     border: 1px solid #5C5F77;
     border-radius: 8px;
     padding: 0;
@@ -241,30 +247,6 @@
 .mp-help-button:hover + .mp-help-tooltip {
     display: block;
 }
-/* 底部按钮 */
-.mp-bottom-controls-group button {
-    padding: 8px 24px;
-    width: 164px;
-    height: 36px;
-    border-radius: 8px;
-    border: 1px solid #5C5F77;
-    background: white;
-    color: #5C5F77;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-size: 14px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    box-shadow: 0 1px 3px rgba(82, 144, 220, 0.1);
-}
-
-.mp-bottom-controls-group button:hover {
-    background: rgba(82, 144, 220, 0.05);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(82, 144, 220, 0.2);
-}
 
 .mp-copy-button:not(:disabled) {
     background: #5290DC !important;
@@ -286,15 +268,6 @@
     cursor: not-allowed !important;
 }
 
-.mp-bottom-controls-group button:disabled {
-    opacity: 0.5;
-    background: white !important;
-    color: #5C5F77 !important;
-    cursor: not-allowed !important;
-    transform: none;
-    border-color: #5C5F77 !important;
-    box-shadow: none;
-}
 /* 关于作者的框 */
 .mp-donate-overlay {
     position: fixed;
@@ -350,7 +323,7 @@
     right: 7px;
     width: 28px;
     height: 28px;
-    background: transparent;
+    background: var(--background-secondary);
     border: none;
     border-radius: 6px;
     font-size: 17px;

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 }
 
 /* 工具栏基础样式 */
-.mp-toolbar, .mp-bottom-bar {
+.mp-bottom-bar {
     padding: 20px 32px;
     position: sticky;
     border-radius: 6px;
@@ -15,18 +15,6 @@
     display: flex;
     align-items: center;
     min-width: 680px;
-}
-
-.mp-toolbar {
-    top: 0;
-    background: rgba(82, 144, 220, 0.03);
-    border-bottom: 1px solid rgba(82, 144, 220, 0.1);
-}
-
-.mp-bottom-bar {
-    bottom: 0;
-    background: rgba(82, 144, 220, 0.02);
-    border-top: 1px solid rgba(82, 144, 220, 0.1);
 }
 
 /* 控件组布局 */
@@ -73,29 +61,29 @@
 .custom-select {
     height: 32px;
     padding: 0 12px;
-    border: 1px solid #5C5F77;
+    border: 1px solid var(--text-muted);
     border-radius: 8px;
-    background: white;
+    background: var(--background-primary);
     display: flex;
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
     user-select: none;
     transition: all 0.2s ease;
-    color: #5C5F77;
-    box-shadow: 0 1px 3px rgba(82, 144, 220, 0.1);
+    color: var(--text-muted);
+    box-shadow: 0 1px 3px var(--background-modifier-box-shadow);
 }
 
 .custom-select:hover {
-    background: #f5f8fc;
-    box-shadow: 0 2px 6px rgba(82, 144, 220, 0.15);
+    background: var(--background-secondary);
+    box-shadow: 0 2px 6px var(--background-modifier-box-shadow);
 }
 
 .custom-select.disabled {
     opacity: 0.5;
-    background: #f5f5f5 !important;
-    color: #999 !important;
-    border-color: #e8e8e8 !important;
+    background: var(--background-secondary) !important;
+    color: var(--text-faint) !important;
+    border-color: var(--background-modifier-border) !important;
     cursor: not-allowed;
     box-shadow: none;
 }
@@ -181,8 +169,8 @@
     padding: 0;
     margin: 0;
     border: none;
-    background: transparent;
-    color: #5C5F77;
+    background: var(--background-primary);
+    color: var(--text-normal);
     outline: none;
 }
 


### PR DESCRIPTION
1.通过修改样式为obsidian内置 css 变量提供了多主题明暗色支持；
2.修改了按钮对齐方式避免太窄导致被吞掉
3.移除了多余的按钮样式保持统一

未来计划：添加对代码块的支持。包括选择代码块风格

一点小建议：样式写的太多后期会比较难以维护，建议能用 obsidian 内置样式就少自己写，以减轻自己的工作量。

ok~感谢夜半

原版亮色样式
![image](https://github.com/user-attachments/assets/928a1b0c-86ce-46b8-b625-ffd70c6c431c)

原版暗色样式
![image](https://github.com/user-attachments/assets/11f936f1-196b-4b58-9882-319e293bdb18)


Github 暗色样式
![image](https://github.com/user-attachments/assets/a19c2208-4523-45e7-b00e-abedf6d08638)
