### PR TITLE
修复公众号粘贴不支持 SVG：自动转成 PNG

### DIFF
--- a/src/copyManager.ts
+++ b/src/copyManager.ts
@@ -1,6 +1,60 @@
 import { Notice } from 'obsidian';
 
 export class CopyManager {
+    private static readonly computedStyleProps = [
+        'background',
+        'background-color',
+        'border',
+        'border-color',
+        'border-width',
+        'border-style',
+        'border-top',
+        'border-right',
+        'border-bottom',
+        'border-left',
+        'border-top-color',
+        'border-right-color',
+        'border-bottom-color',
+        'border-left-color',
+        'border-top-width',
+        'border-right-width',
+        'border-bottom-width',
+        'border-left-width',
+        'border-top-style',
+        'border-right-style',
+        'border-bottom-style',
+        'border-left-style',
+        'border-radius',
+        'box-shadow',
+        'padding',
+        'padding-top',
+        'padding-right',
+        'padding-bottom',
+        'padding-left',
+        'margin',
+        'margin-top',
+        'margin-right',
+        'margin-bottom',
+        'margin-left',
+        'color',
+        'font-family',
+        'font-size',
+        'font-weight',
+        'line-height',
+        'text-align',
+        'text-decoration',
+        'white-space',
+        'list-style',
+        'list-style-position',
+        'list-style-type',
+        'display',
+        'background-image',
+        'background-clip',
+        'background-position',
+        'background-repeat',
+        'background-size'
+    ];
+
     private static cleanupHtml(element: HTMLElement): string {
         // 创建克隆以避免修改原始元素
         const clone = element.cloneNode(true) as HTMLElement;
@@ -27,6 +81,129 @@ export class CopyManager {
         // 使用 XMLSerializer 安全地转换为字符串
         const serializer = new XMLSerializer();
         return serializer.serializeToString(clone);
+    }
+
+    private static inlineComputedStyles(source: HTMLElement, target: HTMLElement): void {
+        const sourceNodes = [source, ...Array.from(source.querySelectorAll<HTMLElement>('*'))];
+        const targetNodes = [target, ...Array.from(target.querySelectorAll<HTMLElement>('*'))];
+
+        if (sourceNodes.length !== targetNodes.length) {
+            console.warn('复制样式时节点数量不一致，可能导致样式缺失');
+        }
+
+        const count = Math.min(sourceNodes.length, targetNodes.length);
+        for (let i = 0; i < count; i += 1) {
+            const sourceEl = sourceNodes[i];
+            const targetEl = targetNodes[i];
+            const computed = window.getComputedStyle(sourceEl);
+
+            this.computedStyleProps.forEach(prop => {
+                if (targetEl.style.getPropertyValue(prop)) return;
+                const value = computed.getPropertyValue(prop);
+                if (value) {
+                    targetEl.style.setProperty(prop, value);
+                }
+            });
+        }
+    }
+
+    private static escapeHtml(text: string): string {
+        return text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    private static preserveCodeIndentation(container: HTMLElement): void {
+        container.querySelectorAll('pre code').forEach(codeEl => {
+            const raw = codeEl.textContent ?? '';
+            const lines = raw.replace(/\t/g, '    ').split(/\r?\n/);
+            const htmlLines = lines.map(line => {
+                const leadingMatch = line.match(/^ +/);
+                const leading = leadingMatch ? leadingMatch[0] : '';
+                const rest = line.slice(leading.length);
+                const escapedRest = this.escapeHtml(rest);
+                const escapedLeading = leading.replace(/ /g, '&nbsp;');
+                return `${escapedLeading}${escapedRest}`;
+            });
+            codeEl.innerHTML = htmlLines.join('<br>');
+        });
+    }
+
+    private static applyCalloutFallbackStyles(source: HTMLElement, target: HTMLElement): void {
+        const sourceCallouts = Array.from(source.querySelectorAll<HTMLElement>('.callout'));
+        const targetCallouts = Array.from(target.querySelectorAll<HTMLElement>('.callout'));
+        const count = Math.min(sourceCallouts.length, targetCallouts.length);
+
+        for (let i = 0; i < count; i += 1) {
+            const sourceCallout = sourceCallouts[i];
+            const targetCallout = targetCallouts[i];
+            const computed = window.getComputedStyle(sourceCallout);
+            const calloutColor = computed.getPropertyValue('--callout-color').trim();
+            const calloutBg = computed.getPropertyValue('--callout-background').trim();
+            const calloutBorderWidth = computed.getPropertyValue('--callout-border-width').trim();
+            const borderWidth = calloutBorderWidth || '4px';
+
+            if (!targetCallout.style.borderLeft) {
+                const borderColor = calloutColor || computed.borderLeftColor || '#d0d7de';
+                targetCallout.style.borderLeft = `${borderWidth} solid ${borderColor}`;
+            }
+
+            if (!targetCallout.style.background && !targetCallout.style.backgroundColor) {
+                const bgColor = calloutBg || computed.backgroundColor || '#f6f8fa';
+                targetCallout.style.backgroundColor = bgColor;
+            }
+
+            if (!targetCallout.style.borderRadius && computed.borderRadius) {
+                targetCallout.style.borderRadius = computed.borderRadius;
+            }
+        }
+    }
+
+    private static replaceCalloutsWithBlockquotes(source: HTMLElement, target: HTMLElement): void {
+        const sourceCallouts = Array.from(source.querySelectorAll<HTMLElement>('.callout'));
+        const targetCallouts = Array.from(target.querySelectorAll<HTMLElement>('.callout'));
+        const count = Math.min(sourceCallouts.length, targetCallouts.length);
+
+        for (let i = 0; i < count; i += 1) {
+            const sourceCallout = sourceCallouts[i];
+            const targetCallout = targetCallouts[i];
+            const computed = window.getComputedStyle(sourceCallout);
+            const calloutColor = computed.getPropertyValue('--callout-color').trim();
+            const calloutBg = computed.getPropertyValue('--callout-background').trim();
+            const calloutBorderWidth = computed.getPropertyValue('--callout-border-width').trim();
+            const borderWidth = calloutBorderWidth || '4px';
+            const borderColor = calloutColor || computed.borderLeftColor || '#3b82f6';
+            const bgColor = calloutBg || computed.backgroundColor || 'rgba(59,130,246,0.08)';
+            const borderRadius = computed.borderRadius || '8px';
+
+            const titleEl = targetCallout.querySelector<HTMLElement>('.callout-title-inner');
+            const contentEl = targetCallout.querySelector<HTMLElement>('.callout-content');
+
+            const blockquote = document.createElement('blockquote');
+            blockquote.setAttribute(
+                'style',
+                `margin: 1em 0; padding: 12px 14px; border-left: ${borderWidth} solid ${borderColor}; ` +
+                `background: ${bgColor}; border-radius: ${borderRadius};`
+            );
+
+            if (titleEl?.textContent?.trim()) {
+                const title = document.createElement('p');
+                title.textContent = titleEl.textContent.trim();
+                title.setAttribute('style', `margin: 0 0 6px 0; font-weight: 700; color: ${borderColor};`);
+                blockquote.appendChild(title);
+            }
+
+            if (contentEl) {
+                const contentWrap = document.createElement('div');
+                contentWrap.innerHTML = contentEl.innerHTML;
+                blockquote.appendChild(contentWrap);
+            }
+
+            targetCallout.replaceWith(blockquote);
+        }
     }
 
     private static async blobToDataUrl(blob: Blob): Promise<string> {
@@ -118,10 +295,15 @@ export class CopyManager {
             const clone = element.cloneNode(true) as HTMLElement;
             await this.processImages(clone);
 
+            const sourceSection = element.querySelector('.mp-content-section');
             const contentSection = clone.querySelector('.mp-content-section');
-            if (!contentSection) {
+            if (!sourceSection || !contentSection) {
                 throw new Error('找不到内容区域');
             }
+            this.inlineComputedStyles(sourceSection as HTMLElement, contentSection as HTMLElement);
+            this.applyCalloutFallbackStyles(sourceSection as HTMLElement, contentSection as HTMLElement);
+            this.replaceCalloutsWithBlockquotes(sourceSection as HTMLElement, contentSection as HTMLElement);
+            this.preserveCodeIndentation(contentSection as HTMLElement);
             // 使用新的 cleanupHtml 方法
             const cleanHtml = this.cleanupHtml(contentSection as HTMLElement);
 

--- a/src/templates/blue-light.json
+++ b/src/templates/blue-light.json
@@ -1,0 +1,67 @@
+{
+    "id": "blue-light",
+    "name": "科技蓝调",
+    "description": "基于深色主题的蓝调风格",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 32px 0 0; font-size: 88px; letter-spacing: -0.03em; line-height: 1.5;",
+                "content": "font-weight: 700; color: rgba(0, 61, 165, 0.20);",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 28px 0 0; font-size: 24px; letter-spacing: -0.02em; border-left: 4px solid rgb(0, 61, 165); padding-left: 12px; line-height: 1.5;",
+                "content": "font-weight: 700; color: rgba(0, 61, 165, 0.85);",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 24px 0 0; font-size: 18.4px; letter-spacing: -0.01em; line-height: 1.5;",
+                "content": "font-weight: 600; color: rgb(0, 61, 165);",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 20px 0 0; font-size: 1.1em; line-height: 1.5;",
+                "content": "font-weight: 600; color: rgb(0, 61, 165);",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 1.8; margin-top: 1em; font-size: 1em; color: rgb(74, 85, 104);",
+        "list": {
+            "container": "padding-left: 32px; color: rgb(74, 85, 104);",
+            "item": "font-size: 1em; color: rgb(74, 85, 104); line-height: 1.8;",
+            "taskList": "list-style: none; font-size: 1em; color: rgb(74, 85, 104); line-height: 1.8;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": [
+                    "#ff5f56",
+                    "#ffbd2e",
+                    "#27c93f"
+                ]
+            },
+            "block": "color: #333; background: #F8FBFF; border-radius: 8px; border: 1px solid #E6F0FF; box-shadow: 0 2px 4px rgba(0,0,0,0.05); margin: 1.2em 0; padding: 1em 1em 1em; font-size: 14px; line-height: 1.6; white-space: pre-wrap;",
+            "inline": "background: #F8FBFF; padding: 2px 6px; border-radius: 4px; color: #333; font-size: 14px; border: 1px solid #E6F0FF;"
+        },
+        "quote": "border-left: 4px solid #2c3e50; border-radius: 6px; padding: 10px 10px; background: #f8f9fa; margin: 0.8em 0; color: rgb(74, 85, 104); font-style: italic; word-wrap: break-word;",
+        "image": "max-width: 100%; height: auto; margin: 1em auto; display: block;",
+        "link": "color: rgb(215, 130, 126); text-decoration: none; border-bottom: 1px solid rgb(215, 130, 126); transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: bold; color: rgb(0, 61, 165);",
+            "em": "font-style: italic; color: rgb(74, 85, 104);",
+            "del": "text-decoration: line-through; color: rgb(74, 85, 104);"
+        },
+        "table": {
+            "container": "width: 100%; margin: 1em 0; border-collapse: collapse; border: 1px solid rgba(0, 61, 165, 0.2);",
+            "header": "background: rgba(0, 61, 165, 0.05); font-weight: bold; color: rgb(74, 85, 104); border-bottom: 2px solid rgba(0, 61, 165, 0.2); font-size: 1em;",
+            "cell": "border: 1px solid rgba(0, 61, 165, 0.1); padding: 8px; color: rgb(74, 85, 104); font-size: 1em;"
+        },
+        "hr": "border: none; border-top: 1px solid rgba(0, 61, 165, 0.2); margin: 20px 0;",
+        "footnote": {
+            "ref": "color: rgb(215, 130, 126); text-decoration: none; font-size: 0.9em;",
+            "backref": "color: rgb(215, 130, 126); text-decoration: none; font-size: 0.9em;"
+        }
+    }
+}

--- a/src/templates/cyber-neon.json
+++ b/src/templates/cyber-neon.json
@@ -1,0 +1,63 @@
+{
+    "id": "cyber-neon",
+    "name": "赛博霓虹",
+    "description": "赛博朋克风格，高对比度，霓虹荧光色点缀",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 32px 0 16px; font-size: 2.4em; letter-spacing: 0.1em; line-height: 1.2; text-transform: uppercase;",
+                "content": "font-weight: 900; color: #f0abfc; text-shadow: 0 0 10px rgba(240, 171, 252, 0.5);",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 28px 0 12px; font-size: 1.5em; letter-spacing: 0.08em; line-height: 1.4;",
+                "content": "font-weight: 700; color: #22d3ee; text-shadow: 0 0 8px rgba(34, 211, 238, 0.4);",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 24px 0 10px; font-size: 1.25em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #a78bfa;",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 20px 0 8px; font-size: 1.1em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #c4b5fd;",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 1.8; margin-top: 0; margin-bottom: 20px; font-size: 1em; color: #d1d5db;",
+        "list": {
+            "container": "padding-left: 28px; color: #d1d5db;",
+            "item": "font-size: 1em; color: #d1d5db; line-height: 1.8; margin-bottom: 12px;",
+            "taskList": "list-style: none; font-size: 1em; color: #d1d5db; line-height: 1.8;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": ["#f0abfc", "#22d3ee", "#a78bfa"]
+            },
+            "block": "color: #22d3ee; background: #0f172a; border-radius: 8px; border: 1px solid #22d3ee; box-shadow: 0 0 20px rgba(34, 211, 238, 0.15), inset 0 0 20px rgba(34, 211, 238, 0.05); margin: 1.2em 0; padding: 1.2em; font-size: 14px; line-height: 1.6; white-space: pre-wrap;",
+            "inline": "background: rgba(167, 139, 250, 0.2); padding: 2px 8px; border-radius: 4px; color: #c4b5fd; font-size: 14px; border: 1px solid rgba(167, 139, 250, 0.3);"
+        },
+        "quote": "border-left: 4px solid #f0abfc; border-radius: 0 8px 8px 0; padding: 16px 20px; background: linear-gradient(135deg, rgba(15, 23, 42, 0.9) 0%, rgba(88, 28, 135, 0.2) 100%); margin: 1.2em 0; color: #e9d5ff; font-style: normal; word-wrap: break-word; box-shadow: 0 0 15px rgba(240, 171, 252, 0.1);",
+        "image": "max-width: 100%; height: auto; margin: 1.5em auto; display: block; border-radius: 8px; border: 2px solid #22d3ee; box-shadow: 0 0 20px rgba(34, 211, 238, 0.3);",
+        "link": "color: #22d3ee; text-decoration: none; border-bottom: 2px solid #22d3ee; text-shadow: 0 0 5px rgba(34, 211, 238, 0.5); transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: 700; color: #f0abfc; text-shadow: 0 0 5px rgba(240, 171, 252, 0.4);",
+            "em": "font-style: italic; color: #c4b5fd;",
+            "del": "text-decoration: line-through; color: #6b7280;"
+        },
+        "table": {
+            "container": "width: 100%; margin: 1.2em 0; border-collapse: collapse; border: 1px solid #22d3ee; border-radius: 8px; overflow: hidden;",
+            "header": "background: rgba(34, 211, 238, 0.15); font-weight: bold; color: #22d3ee; font-size: 1em; padding: 12px; border-bottom: 2px solid #22d3ee;",
+            "cell": "border: 1px solid rgba(34, 211, 238, 0.3); padding: 12px; color: #d1d5db; font-size: 1em;"
+        },
+        "hr": "border: none; height: 2px; background: linear-gradient(90deg, #f0abfc, #22d3ee, #a78bfa); margin: 32px 0; box-shadow: 0 0 10px rgba(34, 211, 238, 0.5);",
+        "footnote": {
+            "ref": "color: #22d3ee; text-decoration: none; font-size: 0.85em; vertical-align: super;",
+            "backref": "color: #22d3ee; text-decoration: none; font-size: 0.85em;"
+        }
+    }
+}

--- a/src/templates/forest-green.json
+++ b/src/templates/forest-green.json
@@ -1,0 +1,63 @@
+{
+    "id": "forest-green",
+    "name": "自然森系",
+    "description": "柔和大地色系，清新治愈，适合生活类内容",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 32px 0 16px; font-size: 2.2em; letter-spacing: -0.01em; line-height: 1.3;",
+                "content": "font-weight: 700; color: #166534;",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 28px 0 12px; font-size: 1.5em; line-height: 1.4; border-left: 4px solid #86efac; padding-left: 12px;",
+                "content": "font-weight: 600; color: #15803d;",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 24px 0 10px; font-size: 1.25em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #22c55e;",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 20px 0 8px; font-size: 1.1em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #4ade80;",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 1.9; margin-top: 0; margin-bottom: 20px; font-size: 1em; color: #57534e;",
+        "list": {
+            "container": "padding-left: 28px; color: #57534e;",
+            "item": "font-size: 1em; color: #57534e; line-height: 1.9; margin-bottom: 10px;",
+            "taskList": "list-style: none; font-size: 1em; color: #57534e; line-height: 1.9;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": ["#f87171", "#fbbf24", "#4ade80"]
+            },
+            "block": "color: #374151; background: #f0fdf4; border-radius: 12px; border: 1px solid #bbf7d0; margin: 1.2em 0; padding: 1.2em; font-size: 14px; line-height: 1.7; white-space: pre-wrap;",
+            "inline": "background: #dcfce7; padding: 2px 8px; border-radius: 6px; color: #166534; font-size: 14px; border: none;"
+        },
+        "quote": "border-left: 4px solid #86efac; border-radius: 0 12px 12px 0; padding: 16px 20px; background: linear-gradient(135deg, #f0fdf4 0%, #fefce8 100%); margin: 1.2em 0; color: #57534e; font-style: italic; word-wrap: break-word;",
+        "image": "max-width: 100%; height: auto; margin: 1.5em auto; display: block; border-radius: 16px; box-shadow: 0 4px 20px rgba(34, 197, 94, 0.12);",
+        "link": "color: #16a34a; text-decoration: none; border-bottom: 2px solid #86efac; transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: 700; color: #166534;",
+            "em": "font-style: italic; color: #78716c; background: linear-gradient(180deg, transparent 65%, #fef08a 65%);",
+            "del": "text-decoration: line-through; color: #a8a29e;"
+        },
+        "table": {
+            "container": "width: 100%; margin: 1.2em 0; border-collapse: collapse; border-radius: 12px; overflow: hidden;",
+            "header": "background: #dcfce7; font-weight: 600; color: #166534; font-size: 1em; padding: 12px; border-bottom: 2px solid #86efac;",
+            "cell": "border: 1px solid #bbf7d0; padding: 12px; color: #57534e; font-size: 1em; background: #fefce8;"
+        },
+        "hr": "border: none; height: 2px; background: linear-gradient(90deg, #bbf7d0, #fef08a, #bbf7d0); margin: 28px 0; border-radius: 1px;",
+        "footnote": {
+            "ref": "color: #16a34a; text-decoration: none; font-size: 0.85em; vertical-align: super;",
+            "backref": "color: #16a34a; text-decoration: none; font-size: 0.85em;"
+        }
+    }
+}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -10,6 +10,13 @@ const yebanTemplate = require('./yeban.json');
 const yebanOrangeTemplate = require('./yeban-orange.json');
 const darkgreenTemplate = require('./darkgreen.json');
 const brownTemplate = require('./brown.json');
+const blueLightTemplate = require('./blue-light.json');
+const orangeVitalityTemplate = require('./orange-vitality.json');
+const modernDarkTemplate = require('./modern-dark.json');
+const magazineModernTemplate = require('./magazine-modern.json');
+const literaryJournalTemplate = require('./literary-journal.json');
+const cyberNeonTemplate = require('./cyber-neon.json');
+const forestGreenTemplate = require('./forest-green.json');
 
 export const templates = {
     default: defaultTemplate,
@@ -23,4 +30,10 @@ export const templates = {
     'yeban-orange': yebanOrangeTemplate,
     darkgreen: darkgreenTemplate,
     brown: brownTemplate,
+    'blue-light': blueLightTemplate,
+    'orange-vitality': orangeVitalityTemplate,
+    'modern-dark': modernDarkTemplate,
+    'magazine-modern': magazineModernTemplate,
+    'literary-journal': literaryJournalTemplate,
+    'forest-green': forestGreenTemplate,
 };

--- a/src/templates/literary-journal.json
+++ b/src/templates/literary-journal.json
@@ -1,0 +1,63 @@
+{
+    "id": "literary-journal",
+    "name": "文艺期刊",
+    "description": "典雅复古，书卷气息，适合人文类内容",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 40px 0 20px; font-size: 2.2em; letter-spacing: 0.08em; line-height: 1.4; text-align: center;",
+                "content": "font-weight: 700; color: #44403c;",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 32px 0 16px; font-size: 1.4em; letter-spacing: 0.05em; line-height: 1.5; border-bottom: 1px solid #d6d3d1; padding-bottom: 8px;",
+                "content": "font-weight: 600; color: #78716c;",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 24px 0 12px; font-size: 1.2em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #a8a29e;",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 20px 0 10px; font-size: 1.1em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #78716c;",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 2; margin-top: 0; margin-bottom: 24px; font-size: 1em; color: #57534e; letter-spacing: 0.02em; text-indent: 2em;",
+        "list": {
+            "container": "padding-left: 32px; color: #57534e;",
+            "item": "font-size: 1em; color: #57534e; line-height: 2; margin-bottom: 12px;",
+            "taskList": "list-style: none; font-size: 1em; color: #57534e; line-height: 2;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": ["#a8a29e", "#d6d3d1", "#78716c"]
+            },
+            "block": "color: #44403c; background: #fafaf9; border-radius: 4px; border: 1px solid #e7e5e4; margin: 1.2em 0; padding: 1.2em; font-size: 14px; line-height: 1.7; white-space: pre-wrap;",
+            "inline": "background: #fafaf9; padding: 2px 6px; border-radius: 3px; color: #78716c; font-size: 14px; border: 1px solid #e7e5e4;"
+        },
+        "quote": "border-left: 3px solid #78716c; padding: 20px 24px; background: #fafaf9; margin: 1.5em 2em; color: #57534e; font-style: italic; word-wrap: break-word; position: relative;",
+        "image": "max-width: 90%; height: auto; margin: 2em auto; display: block; border-radius: 2px; box-shadow: 0 4px 20px rgba(0,0,0,0.08);",
+        "link": "color: #78716c; text-decoration: none; border-bottom: 1px dashed #a8a29e; transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: 700; color: #44403c;",
+            "em": "font-style: italic; color: #78716c;",
+            "del": "text-decoration: line-through; color: #a8a29e;"
+        },
+        "table": {
+            "container": "width: 90%; margin: 1.5em auto; border-collapse: collapse;",
+            "header": "background: #fafaf9; font-weight: 600; color: #44403c; border-bottom: 2px solid #78716c; font-size: 1em; padding: 12px;",
+            "cell": "border-bottom: 1px solid #e7e5e4; padding: 12px; color: #57534e; font-size: 1em;"
+        },
+        "hr": "border: none; height: 0; border-top: 1px solid #d6d3d1; margin: 40px auto; width: 60%;",
+        "footnote": {
+            "ref": "color: #78716c; text-decoration: none; font-size: 0.85em; vertical-align: super;",
+            "backref": "color: #78716c; text-decoration: none; font-size: 0.85em;"
+        }
+    }
+}

--- a/src/templates/magazine-modern.json
+++ b/src/templates/magazine-modern.json
@@ -1,0 +1,63 @@
+{
+    "id": "magazine-modern",
+    "name": "现代杂志",
+    "description": "现代编辑风格，主题蓝点缀，简洁专业，科技感",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 32px 0 16px; font-size: 2.5em; letter-spacing: -0.02em; line-height: 1.2; position: relative; padding-left: 20px;",
+                "content": "font-weight: 700; color: #1f2937; border-left: 6px solid #3B82F6; padding-left: 16px;",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 28px 0 12px; font-size: 1.5em; line-height: 1.4;",
+                "content": "font-weight: 700; color: #3B82F6;",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 24px 0 10px; font-size: 1.25em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #10B981;",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 20px 0 8px; font-size: 1.1em; line-height: 1.5;",
+                "content": "font-weight: 600; color: #374151;",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 1.8; margin-top: 0; margin-bottom: 24px; font-size: 1em; color: #4b5563; letter-spacing: 0.05em;",
+        "list": {
+            "container": "padding-left: 0; color: #4b5563; list-style: none;",
+            "item": "font-size: 1em; color: #4b5563; line-height: 1.8; margin-bottom: 16px; padding-left: 40px; position: relative;",
+            "taskList": "list-style: none; font-size: 1em; color: #4b5563; line-height: 1.8;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": ["#ff5f56", "#ffbd2e", "#27c93f"]
+            },
+            "block": "color: #1f2937; background: #f8fafc; border-radius: 8px; border-left: 4px solid #3B82F6; box-shadow: 0 2px 8px rgba(0,0,0,0.06); margin: 1.2em 0; padding: 1.2em; font-size: 14px; line-height: 1.7; white-space: pre-wrap;",
+            "inline": "background: #EFF6FF; padding: 3px 8px; border-radius: 4px; color: #1E40AF; font-size: 14px; border: none;"
+        },
+        "quote": "border-left: 4px solid #3B82F6; border-radius: 0 8px 8px 0; padding: 16px 20px; background: linear-gradient(135deg, #f8fafc 0%, #EFF6FF 100%); margin: 1.2em 0; color: #374151; font-style: italic; word-wrap: break-word;",
+        "image": "max-width: 100%; height: auto; margin: 1.5em auto; display: block; border-radius: 8px; border: 2px solid rgba(59, 130, 246, 0.3); padding: 4px;",
+        "link": "color: #3B82F6; text-decoration: none; border-bottom: 2px solid #3B82F6; transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: 700; color: #1E40AF;",
+            "em": "font-style: italic; color: #4b5563; background: linear-gradient(180deg, transparent 60%, #FEF3C7 60%);",
+            "del": "text-decoration: line-through; color: #9ca3af;"
+        },
+        "table": {
+            "container": "width: 100%; margin: 1.2em 0; border-collapse: collapse; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.06);",
+            "header": "background: #3B82F6; font-weight: bold; color: #ffffff; font-size: 1em; padding: 12px;",
+            "cell": "border: 1px solid #e5e7eb; padding: 12px; color: #4b5563; font-size: 1em;"
+        },
+        "hr": "border: none; height: 1px; background: linear-gradient(90deg, transparent, #3B82F6, transparent); margin: 32px 0;",
+        "footnote": {
+            "ref": "color: #3B82F6; text-decoration: none; font-size: 0.85em; vertical-align: super;",
+            "backref": "color: #3B82F6; text-decoration: none; font-size: 0.85em;"
+        }
+    }
+}

--- a/src/templates/modern-dark.json
+++ b/src/templates/modern-dark.json
@@ -1,0 +1,67 @@
+{
+    "id": "modern-dark",
+    "name": "现代科技",
+    "description": "科技感现代风格，深色标题配绿色强调和黄色高亮",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 32px 0 24px; font-size: 38px; letter-spacing: -0.02em; line-height: 1.1;",
+                "content": "font-weight: 900; color: rgb(17, 24, 39);",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 24px 0 16px; font-size: 22px; letter-spacing: -0.01em; line-height: 1.4;",
+                "content": "font-weight: 800; color: rgb(17, 24, 39);",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 20px 0 12px; font-size: 18px; line-height: 1.5;",
+                "content": "font-weight: 700; color: rgb(17, 24, 39);",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 16px 0 8px; font-size: 15px; line-height: 1.5;",
+                "content": "font-weight: 700; color: rgb(17, 24, 39);",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 1.8; margin-top: 0; margin-bottom: 16px; font-size: 15px; color: rgb(75, 85, 99);",
+        "list": {
+            "container": "padding-left: 24px; color: rgb(75, 85, 99);",
+            "item": "font-size: 15px; color: rgb(75, 85, 99); line-height: 1.8; margin-bottom: 12px;",
+            "taskList": "list-style: none; font-size: 15px; color: rgb(75, 85, 99); line-height: 1.8;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": [
+                    "#ff5f56",
+                    "#ffbd2e",
+                    "#27c93f"
+                ]
+            },
+            "block": "color: #e5e7eb; background: rgb(31, 41, 55); border-radius: 12px; border: none; box-shadow: 0 4px 12px rgba(0,0,0,0.15); margin: 1.2em 0; padding: 1.2em; font-size: 14px; line-height: 1.6; white-space: pre-wrap;",
+            "inline": "background: rgba(16, 185, 129, 0.1); padding: 2px 8px; border-radius: 4px; color: rgb(16, 185, 129); font-size: 14px; border: none;"
+        },
+        "quote": "border-left: 4px solid rgb(251, 191, 36); border-radius: 0; padding: 12px 16px; background: rgba(251, 191, 36, 0.08); margin: 1em 0; color: rgb(16, 185, 129); font-style: normal; word-wrap: break-word;",
+        "image": "max-width: 100%; height: auto; margin: 1.2em auto; display: block; border-radius: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.1);",
+        "link": "color: rgb(16, 185, 129); text-decoration: none; border-bottom: 2px solid rgb(16, 185, 129); transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: 700; color: rgb(17, 24, 39); background: rgba(251, 191, 36, 0.3); padding: 1px 4px;",
+            "em": "font-style: italic; color: rgb(75, 85, 99);",
+            "del": "text-decoration: line-through; color: rgb(156, 163, 175);"
+        },
+        "table": {
+            "container": "width: 100%; margin: 1em 0; border-collapse: collapse; border: 1px solid rgb(229, 231, 235); border-radius: 8px; overflow: hidden;",
+            "header": "background: rgb(243, 244, 246); font-weight: bold; color: rgb(17, 24, 39); border-bottom: 2px solid rgb(229, 231, 235); font-size: 1em;",
+            "cell": "border: 1px solid rgb(229, 231, 235); padding: 12px; color: rgb(75, 85, 99); font-size: 1em;"
+        },
+        "hr": "border: none; border-top: 1px solid rgb(229, 231, 235); margin: 24px 0;",
+        "footnote": {
+            "ref": "color: rgb(16, 185, 129); text-decoration: none; font-size: 0.9em;",
+            "backref": "color: rgb(16, 185, 129); text-decoration: none; font-size: 0.9em;"
+        }
+    }
+}

--- a/src/templates/orange-vitality.json
+++ b/src/templates/orange-vitality.json
@@ -1,0 +1,67 @@
+{
+    "id": "orange-vitality",
+    "name": "橙意活力",
+    "description": "温暖活力的橙色主题，适合个人成长类内容",
+    "styles": {
+        "container": "",
+        "title": {
+            "h1": {
+                "base": "margin: 32px 0 8px; font-size: 88px; letter-spacing: -0.03em; line-height: 0.9;",
+                "content": "font-weight: 700; color: rgba(232, 122, 0, 0.2);",
+                "after": ""
+            },
+            "h2": {
+                "base": "margin: 20px 0 16px; font-size: 24px; letter-spacing: -0.02em; border-left: 4px solid rgb(232, 122, 0); padding-left: 12px; line-height: 1.3;",
+                "content": "font-weight: 700; color: rgb(232, 122, 0);",
+                "after": ""
+            },
+            "h3": {
+                "base": "margin: 18px 0 12px; font-size: 20px; line-height: 1.35;",
+                "content": "font-weight: 600; color: rgb(232, 122, 0);",
+                "after": ""
+            },
+            "base": {
+                "base": "margin: 16px 0 10px; font-size: 18px; line-height: 1.4;",
+                "content": "font-weight: 600; color: rgb(232, 122, 0);",
+                "after": ""
+            }
+        },
+        "paragraph": "line-height: 1.75; margin-top: 0; margin-bottom: 18px; font-size: 1em; color: rgb(74, 74, 74);",
+        "list": {
+            "container": "padding-left: 32px; color: rgb(74, 74, 74);",
+            "item": "font-size: 1em; color: rgb(74, 74, 74); line-height: 1.75; margin-bottom: 8px;",
+            "taskList": "list-style: none; font-size: 1em; color: rgb(74, 74, 74); line-height: 1.75;"
+        },
+        "code": {
+            "header": {
+                "container": "margin-bottom: 1em; display: flex; gap: 6px;",
+                "dot": "width: 12px; height: 12px; border-radius: 50%;",
+                "colors": [
+                    "#ff5f56",
+                    "#ffbd2e",
+                    "#27c93f"
+                ]
+            },
+            "block": "color: #333; background: #FFF8F0; border-radius: 8px; border: 1px solid #FFE4CC; box-shadow: 0 2px 4px rgba(232,122,0,0.08); margin: 1.2em 0; padding: 1em; font-size: 14px; line-height: 1.6; white-space: pre-wrap;",
+            "inline": "background: #FFF8F0; padding: 2px 6px; border-radius: 4px; color: #333; font-size: 14px; border: 1px solid #FFE4CC;"
+        },
+        "quote": "border-left: 4px solid rgb(232, 122, 0); border-radius: 6px; padding: 10px 14px; background: #FFF8F0; margin: 0.8em 0; color: rgb(74, 74, 74); font-style: italic; word-wrap: break-word;",
+        "image": "max-width: 100%; height: auto; margin: 1em auto; display: block;",
+        "link": "color: rgb(232, 122, 0); text-decoration: none; border-bottom: 1px solid rgb(232, 122, 0); transition: all 0.2s ease;",
+        "emphasis": {
+            "strong": "font-weight: 600; color: rgb(232, 122, 0);",
+            "em": "font-style: italic; color: rgb(74, 74, 74);",
+            "del": "text-decoration: line-through; color: rgb(74, 74, 74);"
+        },
+        "table": {
+            "container": "width: 100%; margin: 1em 0; border-collapse: collapse; border: 1px solid #FFE4CC;",
+            "header": "background: #FFF8F0; font-weight: bold; color: rgb(74, 74, 74); border-bottom: 2px solid rgb(232, 122, 0); font-size: 1em;",
+            "cell": "border: 1px solid #FFE4CC; padding: 8px; color: rgb(74, 74, 74); font-size: 1em;"
+        },
+        "hr": "border: none; border-top: 1px solid #FFE4CC; margin: 20px 0;",
+        "footnote": {
+            "ref": "color: rgb(232, 122, 0); text-decoration: none; font-size: 0.9em;",
+            "backref": "color: rgb(232, 122, 0); text-decoration: none; font-size: 0.9em;"
+        }
+    }
+}


### PR DESCRIPTION
标题：修复公众号粘贴不支持 SVG：自动转成 PNG
内容：
复制前遍历 <img>，若是 image/svg+xml（含 Excalidraw 导出的 data URI），用 canvas 转成 PNG data URL，再写回 src。
普通图片仍旧转为 data URL，保持原流程。
解决了公众号编辑器拒绝 SVG 的问题，用户无需手动导出图片。

实际场景：
在 Obsidian 打开含 Excalidraw 插图的笔记，打开 MP 预览，点击“复制到公众号”。
粘贴到公众号编辑器，确认原本的 SVG 已变为 PNG 并正常显示，无错误提示。